### PR TITLE
Remove async, switch out rayon with threadpool

### DIFF
--- a/coil/Cargo.toml
+++ b/coil/Cargo.toml
@@ -21,12 +21,12 @@ serde = "1.0"
 rmp-serde = "0.14"
 thiserror = "1.0"
 inventory = "0.1"
-coil_proc_macro = "0.2.0"
+coil_proc_macro = { path = "../coil_proc_macro/" }
 futures = "0.3.5"
 async-trait = "0.1.36"
 timer = { version = "3.0", package = "futures-timer" }
 log = "0.4.11"
-channel = { version = "1.4.0", package = "async-channel" }
+channel = { version = "0.10.0", package = "flume" }
 itoa = "0.4.6"
 serde_json = { version = "1.0", optional = true}
 

--- a/coil/Cargo.toml
+++ b/coil/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 sqlx = { version = "0.5", default-features = false, features = ["postgres", "macros", "runtime-async-std-rustls", "migrate"] }
-rayon = "1.3"
+threadpool = "1"
 serde = "1.0"
 rmp-serde = "0.14"
 thiserror = "1.0"
@@ -26,9 +26,10 @@ futures = "0.3.5"
 async-trait = "0.1.36"
 timer = { version = "3.0", package = "futures-timer" }
 log = "0.4.11"
-channel = { version = "0.10.0", package = "flume" }
+channel = { version = "0.10", package = "flume" }
 itoa = "0.4.6"
 serde_json = { version = "1.0", optional = true}
+num_cpus = "1"
 
 [dev-dependencies]
 once_cell = "1.4"

--- a/coil/migrations/20200804234125_tasks.sql
+++ b/coil/migrations/20200804234125_tasks.sql
@@ -2,7 +2,6 @@
 CREATE TABLE IF NOT EXISTS _background_tasks (
   id BIGSERIAL PRIMARY KEY NOT NULL,
   job_type TEXT NOT NULL,
-  is_async BOOLEAN NOT NULL,
   -- priority INTEGER NOT NULL,
   data BYTEA NOT NULL,
   retries INTEGER NOT NULL DEFAULT 0,

--- a/coil/src/error.rs
+++ b/coil/src/error.rs
@@ -18,9 +18,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Error building the Rayon threadpool
-    #[error("Building pool failed {0}")]
-    Build(#[from] rayon::ThreadPoolBuildError),
     /// Error Enqueing a task for execution later
     #[error(transparent)]
     Enqueue(#[from] EnqueueError),

--- a/coil/src/job.rs
+++ b/coil/src/job.rs
@@ -17,7 +17,6 @@
 use crate::error::{EnqueueError, PerformError};
 use serde::{de::DeserializeOwned, Serialize};
 use sqlx::{Executor, Postgres};
-use std::sync::Arc;
 
 /// Background job
 #[async_trait::async_trait]
@@ -33,9 +32,6 @@ pub trait Job: Serialize + DeserializeOwned {
     const JOB_TYPE: &'static str;
     #[doc(hidden)]
 
-    /// Marker for whether this trait should be executed with `perform_async`
-    const ASYNC: bool;
-
     /// inserts the job into the Postgres Database
     async fn enqueue<'a, C>(self, conn: C) -> Result<(), EnqueueError>
     where
@@ -48,16 +44,6 @@ pub trait Job: Serialize + DeserializeOwned {
     #[doc(hidden)]
     fn perform(self, _: &Self::Environment, _: &sqlx::PgPool) -> Result<(), PerformError> {
         panic!("Running Sync job when it should be async!");
-    }
-
-    /// Logic for running an asynchronous job
-    #[doc(hidden)]
-    async fn perform_async(
-        self,
-        _: Arc<Self::Environment>,
-        _: &sqlx::PgPool,
-    ) -> Result<(), PerformError> {
-        panic!("Running Async job when it should be sync!");
     }
 }
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.4.0"
 assert_matches = "1.3.0"
 anyhow = "1.0.32"
 antidote = "1.0.0"
-channel = { version = "1.4.0", package = "async-channel" }
+channel = { version = "0.10", package = "flume" }
 timer = { version = "3.0", package = "futures-timer" }
 
 [[test]]

--- a/integration_tests/tests/test_guard.rs
+++ b/integration_tests/tests/test_guard.rs
@@ -24,7 +24,7 @@ impl<'a, Env> TestGuard<'a, Env> {
             .idle_timeout(std::time::Duration::from_millis(1000))
             .connect_lazy(&crate::DATABASE_URL)
             .unwrap();
-        let builder = Runner::builder(env, crate::Executor, &pg_pool);
+        let builder = Runner::builder(env, &pg_pool);
         GuardBuilder { builder }
     }
 
@@ -34,7 +34,7 @@ impl<'a, Env> TestGuard<'a, Env> {
         (
             Self::builder(env)
                 .on_finish(move |_| {
-                    let _ = smol::block_on(tx.send(coil::Event::Dummy));
+                    let _ = tx.send(coil::Event::Dummy);
                 })
                 .num_threads(4)
                 .build(),
@@ -50,7 +50,7 @@ impl<'a> TestGuard<'a, ()> {
             Self::builder(())
                 .num_threads(4)
                 .on_finish(move |_| {
-                    let _ = smol::block_on(tx.send(coil::Event::Dummy));
+                    let _ = tx.send(coil::Event::Dummy);
                 })
                 .build(),
             rx,
@@ -70,11 +70,6 @@ impl<Env> GuardBuilder<Env> {
 
     pub fn num_threads(mut self, threads: usize) -> Self {
         self.builder = self.builder.num_threads(threads);
-        self
-    }
-
-    pub fn max_tasks(mut self, max_tasks: usize) -> Self {
-        self.builder = self.builder.max_tasks(max_tasks);
         self
     }
 

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ let
   moz_overlay = (import "/home/insipx/.config/nixpkgs/overlays/rust-overlay.nix");
   nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
   unstable = import (fetchTarball "channel:nixos-unstable") {};
-  rustnightly = ((nixpkgs.rustChannelOf { date = "2021-01-31"; channel = "nightly"; }).rust.override { extensions = [ "rust-src" "rust-analysis" "rustfmt-preview" ]; targets = ["wasm32-unknown-unknown"]; });
+  rustnightly = ((nixpkgs.rustChannelOf { date = "2021-03-26"; channel = "nightly"; }).rust.override { extensions = [ "rust-src" "rust-analysis" ]; });
 
 in
   with nixpkgs;


### PR DESCRIPTION
Should hopefully better deal with timeouts and error handling, while making the code overall simpler. Async was a 'cool' feature but it was useless in the long-run. If dealing with lots of async tasks, putting them on the default executor a user is already using is better and more manageable than this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/insipx/coil/11)
<!-- Reviewable:end -->
